### PR TITLE
Allow to configure xinetd services from pillar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.kitchen/
+Gemfile.lock

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -1,0 +1,74 @@
+<%
+require 'socket'
+
+# @return [String] public IP address of workstation used for egress traffic
+def local_ip
+  @local_ip ||= begin
+    # turn off reverse DNS resolution temporarily
+    orig, Socket.do_not_reverse_lookup = Socket.do_not_reverse_lookup, true
+
+    UDPSocket.open do |s|
+      s.connect '64.233.187.99', 1 # a google IP, does not hit network
+      s.addr.last
+    end
+  ensure
+    Socket.do_not_reverse_lookup = orig
+  end
+end
+
+# @return [Integer] default polipo listening port
+def local_port ; 8123 ; end
+
+# @return [String] the polipo proxy URL
+def http_proxy_url ; "http://#{local_ip}:#{local_port}" ; end
+
+# @return [TrueClass,FalseClass] whether or not the polipo port is listening
+def proxy_running?
+  socket = TCPSocket.new(local_ip, local_port)
+  true
+rescue SocketError, Errno::ECONNREFUSED,
+  Errno::EHOSTUNREACH, Errno::ENETUNREACH, IOError
+  false
+rescue Errno::EPERM, Errno::ETIMEDOUT
+  false
+ensure
+  socket && socket.close
+end
+%>
+---
+driver:
+  name: docker
+  use_sudo: true
+  require_chef_omnibus: false
+  <% if proxy_running? %>
+  http_proxy: <%= http_proxy_url %>
+  https_proxy: <%= http_proxy_url %>
+  <% end %>
+
+driver_config:
+  provision_command:
+    - sed -i 's/http\:\/\/archive/http\:\/\/us.archive/g' /etc/apt/sources.list
+    - apt-get clean && rm -rf /var/lib/apt/lists/* && apt-get update
+    <% if proxy_running? %>
+    - echo 'Acquire::http::Proxy "<%= http_proxy_url %>";' > /etc/apt/apt.conf.d/proxy
+    - "env http_proxy=<%= http_proxy_url %> bash -c 'curl -sL http://www.chef.io/chef/install.sh | bash'"
+    - curl -o bootstrap-salt.sh -sL https://bootstrap.saltstack.com
+    - env http_proxy=<%= http_proxy_url %> bash bootstrap-salt.sh -X -d -H <%= http_proxy_url %>
+    <% else %>
+    - "curl -sL http://www.chef.io/chef/install.sh | bash"
+    - curl -o bootstrap-salt.sh -sL https://bootstrap.saltstack.com
+    - bash bootstrap-salt.sh -X -d
+    <% end %>
+
+provisioner:
+  # installs from an http:// source to enable better caching through
+  # http_proxy, and yes, this is a bit evil
+<% if proxy_running? %>
+  http_proxy: <%= http_proxy_url %>
+  https_proxy: <%= http_proxy_url %>
+  chef_omnibus_url: http://www.chef.io/chef/install.sh
+  chef_bootstrap_url: http://www.chef.io/chef/install.sh
+  additional_minion_config:
+    proxy_host: <%= (http_proxy_url.split(":")[1]).split("/")[2] %>
+    proxy_port: <%= http_proxy_url.split(":")[2] %>
+<% end %>

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,31 @@
+<%
+require 'yaml'
+formula = YAML.load_file('FORMULA')
+formula_name = formula['name']
+%>
+---
+platforms:
+  - name: ubuntu-14.04
+  - name: ubuntu-16.04
+
+provisioner:
+  name: salt_solo
+  salt_install: bootstrap
+  salt_bootstrap_url: https://bootstrap.saltstack.com
+  salt_version: latest
+  pillars-from-files:
+    <%= formula_name %>.sls: pillar.example
+  pillars:
+    top.sls:
+      base:
+        '*':
+          - <%= formula_name %>
+  log_level: <%= ENV['SALT_DEBUG_LEVEL'] || 'debug' %>
+  formula: <%= formula_name %>
+  state_top:
+    base:
+      '*':
+        - <%= formula_name %>
+
+suites:
+  - name: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: ruby
+
+rvm:
+  - 2.2.5
+
+sudo: required
+services: docker
+
+env:
+  matrix:
+  - INSTANCE=default-ubuntu-1404
+  - INSTANCE=default-ubuntu-1604
+
+# https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142455888
+before_script: sudo iptables -L DOCKER || sudo iptables -N DOCKER
+
+install:
+  # setup ci for test formula
+  - export BUNDLE_GEMFILE=$PWD/Gemfile
+  - bundle install
+
+script:
+  # Run unit tests
+  - KITCHEN_LOCAL_YAML=.kitchen.docker.yml bundle exec kitchen test ${INSTANCE}

--- a/FORMULA
+++ b/FORMULA
@@ -1,0 +1,8 @@
+name: xinetd
+os: Ubuntu
+os_family: Debian
+version: 201705
+release: 1
+minimum_version: 2016.11.4
+summary: Formula for installing xinetd
+description: Formula for installing xinetd

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+ruby '2.2.5'
+
+gem "test-kitchen"
+gem "kitchen-docker"
+gem "kitchen-salt", :git => 'https://github.com/devopxteam/kitchen-salt.git'
+gem 'kitchen-inspec'
+gem "kitchen-vagrant"

--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,13 @@ Available states
 .. contents::
     :local:
 
-``xinetd``
+``xinetd.install``
 ----------
 
 Installs the xinetd package and starts the daemon.
 
 
+``xinetd.config``
+----------
+
+Configure xinetd services based on pillar data.

--- a/pillar.example
+++ b/pillar.example
@@ -1,0 +1,14 @@
+xinetd:
+  services:
+    # Configure custom xinetd services (Options are not checked)
+    echo:
+      description: An xinetd internal service which echo's characters back to
+      # yes or no values needs to be escaped otherwise are treated as booleans
+      disable: 'yes'
+      type: INTERNAL
+      id: echo-stream
+      socket_type: stream
+      protocol: tcp
+      user: root
+      # yes or no values needs to be escaped otherwise are treated as booleans
+      wait: 'no'

--- a/test/integration/default/serverspec/xinetd_spec.rb
+++ b/test/integration/default/serverspec/xinetd_spec.rb
@@ -1,0 +1,19 @@
+require 'serverspec'
+
+# Required by serverspec
+set :backend, :exec
+
+describe "xinetd" do
+  it "package is installed" do
+    expect(package("xinetd")).to be_installed
+  end
+
+  it "service is enabled" do
+    expect(service("xinetd")).to be_enabled
+  end
+
+  it "service is running" do
+    expect(service("xinetd")).to be_running
+  end
+
+end

--- a/xinetd/config.sls
+++ b/xinetd/config.sls
@@ -1,0 +1,16 @@
+{%- from "xinetd/map.jinja" import xinetd with context -%}
+
+{%- if xinetd.services is iterable %}
+{%- for service, config in xinetd.services.iteritems() %}
+xinetd_{{ service }}_config:
+  file.managed:
+    - name: /etc/xinetd.d/{{ service }}
+    - source: salt://xinetd/files/config_template
+    - template: jinja
+    - context:
+        service: {{ service }}
+        config: {{ config }}
+    - watch_in:
+        service: xinetd
+{% endfor %}
+{% endif %}

--- a/xinetd/files/config_template
+++ b/xinetd/files/config_template
@@ -1,0 +1,14 @@
+# -----------------------------------
+# THIS FILE IS MANAGED BY SALTSTACK
+# MANUAL CHANGES WILL BE OVERRIDEN
+# -----------------------------------
+{% if config.description is defined %}
+# description: {{ config.description }}
+{% endif -%}
+service {{ service }} {
+{% for k, v in config.iteritems() -%}
+{%- if k != 'description' -%}
+{{ '%-15s' | format(k) | indent(2, true) ~ ' = ' ~ v }}
+{% endif -%}
+{% endfor -%}
+}

--- a/xinetd/init.sls
+++ b/xinetd/init.sls
@@ -1,20 +1,3 @@
-{%- from "xinetd/map.jinja" import xinetd with context -%}
-
-xinetd:
-  pkg.installed:
-    - name: {{ xinetd.pkg }}
-  service.running:
-    - name: {{ xinetd.service }}
-    - enable: True
-
-# The following states are inert by default and can be used by other states to
-# trigger a restart or reload as needed.
-xinetd-reload:
-  module.wait:
-    - name: service.reload
-    - m_name: {{ xinetd.service }}
-
-xinetd-restart:
-  module.wait:
-    - name: service.restart
-    - m_name: {{ xinetd.service }}
+include:
+  - xinetd.install
+  - xinetd.config

--- a/xinetd/install.sls
+++ b/xinetd/install.sls
@@ -1,0 +1,20 @@
+{%- from "xinetd/map.jinja" import xinetd with context -%}
+
+xinetd:
+  pkg.installed:
+    - name: {{ xinetd.pkg }}
+  service.running:
+    - name: {{ xinetd.service }}
+    - enable: True
+
+# The following states are inert by default and can be used by other states to
+# trigger a restart or reload as needed.
+xinetd-reload:
+  module.wait:
+    - name: service.reload
+    - m_name: {{ xinetd.service }}
+
+xinetd-restart:
+  module.wait:
+    - name: service.restart
+    - m_name: {{ xinetd.service }}

--- a/xinetd/map.jinja
+++ b/xinetd/map.jinja
@@ -1,4 +1,13 @@
-{% set xinetd = { 
-        'pkg': 'xinetd',
-        'service': 'xinetd',
-    } %}
+{% set default_settings = salt['grains.filter_by']({
+  'default': {
+    'pkg': 'xinetd',
+    'service': 'xinetd',
+  },
+}, merge=salt['pillar.get']('xinetd:lookup')) %}
+
+{% set xinetd = salt['pillar.get'](
+    'xinetd',
+    default=default_settings,
+    merge=True
+  )
+%}


### PR DESCRIPTION
This PR does the following:

- Adds functionality to configure xinetd services using pillar data
- Add configuration for tests with Kitchen CI and Travis CI