### PR TITLE
Update for compatibility with SaltStack 2019.2

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,8 +5,8 @@ formula_name = formula['name']
 %>
 ---
 platforms:
-  - name: ubuntu-14.04
   - name: ubuntu-16.04
+  - name: ubuntu-18.04
 
 provisioner:
   name: salt_solo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: ruby
 
 rvm:
-  - 2.2.5
+  - 2.4.1
 
 sudo: required
 services: docker
 
 env:
   matrix:
-  - INSTANCE=default-ubuntu-1404
   - INSTANCE=default-ubuntu-1604
+  - INSTANCE=default-ubuntu-1804
 
 # https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142455888
 before_script: sudo iptables -L DOCKER || sudo iptables -N DOCKER

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
-ruby '2.2.5'
+ruby '2.4.1'
 
-gem "test-kitchen"
+gem "test-kitchen", '>=2.2.4'
 gem "kitchen-docker"
-gem "kitchen-salt", :git => 'https://github.com/devopxteam/kitchen-salt.git'
+gem "kitchen-salt"
 gem 'kitchen-inspec'
 gem "kitchen-vagrant"

--- a/xinetd/config.sls
+++ b/xinetd/config.sls
@@ -9,7 +9,7 @@ xinetd_{{ service }}_config:
     - template: jinja
     - context:
         service: {{ service }}
-        config: {{ config }}
+        config: {{ config|tojson }}
     - watch_in:
         service: xinetd
 {% endfor %}


### PR DESCRIPTION
Update for compatibility with SaltStack 2019.2
    
As stated in https://docs.saltstack.com/en/latest/topics/releases/2019.2.0.html
Add the usage of `tojson` filter. This change is compatible with 2018.3.3 as per that docs.
